### PR TITLE
Add raw-loader into webpack config

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ my-app/
       App.js
       App.test.js
     Page/
+      Page.inline.svg
       Page.css
     index.js
 ```
@@ -118,6 +119,7 @@ Currently it includes something more than original Create React App package:
 * [webpack-bem-loader](https://github.com/bem/webpack-bem-loader)
 * [babel-plugin-bem-import](https://github.com/bem/babel-plugin-bem-import)
 * [bem-react-core](https://github.com/bem/bem-react-core)
+* [raw-loader](https://github.com/webpack-contrib/raw-loader) includes content of *.inline.* files
 
 ## Contributing
 

--- a/packages/bem-react-scripts/config/webpack.config.dev.js
+++ b/packages/bem-react-scripts/config/webpack.config.dev.js
@@ -178,6 +178,7 @@ module.exports = {
           /\.gif$/,
           /\.jpe?g$/,
           /\.png$/,
+          /\.inline\.\w+$/,
         ],
         loader: 'file-loader',
         options: {
@@ -213,8 +214,12 @@ module.exports = {
           { loader: 'postcss-loader' },
         ],
       },
+      {
+        test: /\.inline\.\w+$/,
+        loader: 'raw-loader',
+      },
       // ** STOP ** Are you adding a new loader?
-      // Remember to add the new extension(s) to the "url" loader exclusion list.
+      // Remember to add the new extension(s) to the "file" loader exclusion list.
     ],
   },
   plugins: [

--- a/packages/bem-react-scripts/config/webpack.config.prod.js
+++ b/packages/bem-react-scripts/config/webpack.config.prod.js
@@ -148,6 +148,7 @@ module.exports = {
           /\.gif$/,
           /\.jpe?g$/,
           /\.png$/,
+          /\.inline\.\w+$/,
         ],
         loader: 'file-loader',
         options: {
@@ -227,8 +228,12 @@ module.exports = {
         ),
         // Note: this won't work without `new ExtractTextPlugin()` in `plugins`.
       },
+      {
+        test: /\.inline\.\w+$/,
+        loader: 'raw-loader',
+      },
       // ** STOP ** Are you adding a new loader?
-      // Remember to add the new extension(s) to the "url" loader exclusion list.
+      // Remember to add the new extension(s) to the "file" loader exclusion list.
     ],
   },
   plugins: [

--- a/packages/bem-react-scripts/package.json
+++ b/packages/bem-react-scripts/package.json
@@ -57,6 +57,7 @@
     "object-assign": "4.1.1",
     "postcss-loader": "1.3.3",
     "promise": "7.1.1",
+    "raw-loader": "^0.5.1",
     "react-dev-utils": "^0.5.2",
     "recursive-readdir": "2.1.0",
     "strip-ansi": "3.0.1",


### PR DESCRIPTION
example with svg:

```js
// importing
import Icon from './Component.inline.svg';

// straightforward inlining
content() {
    return <span dangerouslySetInnerHTML={{__html: Icon}}/>;
}
```