### PR TITLE
Add levels to main src for Babel-loader

### DIFF
--- a/packages/bem-react-scripts/config/webpack.config.dev.js
+++ b/packages/bem-react-scripts/config/webpack.config.dev.js
@@ -157,7 +157,7 @@ module.exports = {
             },
           },
         ],
-        include: paths.appSrc,
+        include: [paths.appSrc].concat(Object.keys(paths.appLevels)),
       },
       // ** ADDING/UPDATING LOADERS **
       // The "url" loader handles all assets unless explicitly excluded.

--- a/packages/bem-react-scripts/config/webpack.config.prod.js
+++ b/packages/bem-react-scripts/config/webpack.config.prod.js
@@ -192,7 +192,7 @@ module.exports = {
             },
           },
         ],
-        include: paths.appSrc,
+        include: [paths.appSrc].concat(Object.keys(paths.appLevels)),
       },
       // The notation here is somewhat confusing.
       // "postcss" loader applies autoprefixer to our CSS.


### PR DESCRIPTION
After these changes example shown below will work:

```json
{
    "root": true,
    "levels": {
        "src/components": {},
        "node_modules/bem-react-components/blocks": {}
    },
    "modules": {
        "create-bem-react-app": { "default": "stuff" }
    }
}
```
