### PR TITLE
add sets support

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,9 +117,18 @@ Your app is ready to be deployed!
 Currently it includes something more than original Create React App package:
 
 * [webpack-bem-loader](https://github.com/bem/webpack-bem-loader)
+* [bem/sdk.config](https://github.com/bem/bem-sdk/blob/master/packages/config/README.md#config-example)
 * [babel-plugin-bem-import](https://github.com/bem/babel-plugin-bem-import)
 * [bem-react-core](https://github.com/bem/bem-react-core)
 * [raw-loader](https://github.com/webpack-contrib/raw-loader) includes content of *.inline.* files
+
+## Building multiple bundles
+
+If you want to make several bundles and have their own implementation of blocks, you need to use [sets](https://github.com/bem/bem-sdk/blob/master/packages/config/README.md#config-example)
+
+1. Add sets in ```.bemrc```
+2. Build the project. You can specify some options for [parallel-webpack](https://github.com/trivago/parallel-webpack) (watch, maxRetries, stats)
+3. Run app with ```npm run start set-name```
 
 ## Contributing
 

--- a/packages/bem-react-scripts/config/paths.js
+++ b/packages/bem-react-scripts/config/paths.js
@@ -13,7 +13,7 @@
 const path = require('path');
 const fs = require('fs');
 const url = require('url');
-const bemConfig = require('bem-config')();
+const bemConfig = require('@bem/sdk.config')();
 const userOptions = bemConfig.moduleSync('create-bem-react-app');
 const levels = bemConfig.levelMapSync();
 
@@ -87,6 +87,7 @@ module.exports = {
   appPackageJson: resolveApp(userOptions.appPackageJson),
   appSrc: resolveApp(userOptions.appSrc),
   appLevels: levels,
+  appSets: bemConfig.getSync().sets,
   appTarget: userOptions.target,
   yarnLockFile: resolveApp(userOptions.yarnLockFile),
   testsSetup: resolveApp(userOptions.testsSetup),
@@ -116,6 +117,7 @@ module.exports = {
   appPackageJson: resolveApp(userOptions.appPackageJson),
   appSrc: resolveApp(userOptions.appSrc),
   appLevels: levels,
+  appSets: bemConfig.getSync().sets,
   appTarget: userOptions.target,
   yarnLockFile: resolveApp(userOptions.yarnLockFile),
   testsSetup: resolveApp(userOptions.testsSetup),

--- a/packages/bem-react-scripts/config/webpack.config.dev.js
+++ b/packages/bem-react-scripts/config/webpack.config.dev.js
@@ -33,6 +33,9 @@ const publicUrl = '';
 // Get environment variables to inject into our app.
 const env = getClientEnvironment(publicUrl);
 
+// Get setName name, after start app like `npm run start setName`
+const setName = process.argv[2];
+
 // This is the development configuration.
 // It is focused on developer experience and fast rebuilds.
 // The production configuration is different and lives in a separate file.
@@ -68,13 +71,13 @@ module.exports = {
   ],
   output: {
     // Next line is not used in dev but WebpackDevServer crashes without it:
-    path: paths.appBuild,
+    path: setName ? `${paths.appBuild}/${setName}` : paths.appBuild,
     // Add /* filename */ comments to generated require()s in the output.
     pathinfo: true,
     // This does not produce a real file. It's just the virtual path that is
     // served by WebpackDevServer in development. This is the JS bundle
     // containing code from all our entry points, and the Webpack runtime.
-    filename: 'static/js/bundle.js',
+    filename: setName ? `static/js/${setName}.bundle.js` : `static/js/[name].bundle.js`,
     // This is the URL that app is served from. We use "/" in development.
     publicPath: publicPath,
   },
@@ -232,6 +235,7 @@ module.exports = {
     new HtmlWebpackPlugin({
       inject: true,
       template: paths.appHtml,
+      filename: setName ? `${paths.appBuild}/${setName}/index.html` : `${paths.appBuild}/index.html`,
     }),
     // Makes some environment variables available to the JS code, for example:
     // if (process.env.NODE_ENV === 'development') { ... }. See `./env.js`.

--- a/packages/bem-react-scripts/config/webpack.config.prod.js
+++ b/packages/bem-react-scripts/config/webpack.config.prod.js
@@ -42,261 +42,272 @@ if (env.stringified['process.env'].NODE_ENV !== '"production"') {
   throw new Error('Production builds must have NODE_ENV=production.');
 }
 
-// Note: defined here because it will be used more than once.
-const cssFilename = 'static/css/[name].[contenthash:8].css';
-
-// ExtractTextPlugin expects the build output to be flat.
-// (See https://github.com/webpack-contrib/extract-text-webpack-plugin/issues/27)
-// However, our output is structured with css, js and media folders.
-// To have this structure working with relative paths, we have to use custom options.
-const extractTextPluginOptions = shouldUseRelativeAssetPaths
-  ? // Making sure that the publicPath goes back to to build folder.
-    { publicPath: Array(cssFilename.split('/').length).join('../') }
-  : {};
-
 // This is the production configuration.
 // It compiles slowly and is focused on producing a fast and minimal bundle.
 // The development configuration is different and lives in a separate file.
-module.exports = {
-  // Don't attempt to continue if there are any errors.
-  bail: true,
-  // We generate sourcemaps in production. This is slow but gives good results.
-  // You can exclude the *.map files from the build during deployment.
-  devtool: 'source-map',
-  // In production, we only want to load the polyfills and the app code.
-  entry: [require.resolve('./polyfills'), paths.appIndexJs],
-  output: {
-    // The build folder.
-    path: paths.appBuild,
-    // Generated JS file names (with nested folders).
-    // There will be one main bundle, and one file per asynchronous chunk.
-    // We don't currently advertise code splitting but Webpack supports it.
-    filename: 'static/js/[name].[chunkhash:8].js',
-    chunkFilename: 'static/js/[name].[chunkhash:8].chunk.js',
-    // We inferred the "public path" (such as / or /my-project) from homepage.
-    publicPath: publicPath,
-  },
-  resolve: {
-    // This allows you to set a fallback for where Webpack should look for modules.
-    // We read `NODE_PATH` environment variable in `paths.js` and pass paths here.
-    // We placed these paths second because we want `node_modules` to "win"
-    // if there are any conflicts. This matches Node resolution mechanism.
-    // https://github.com/facebookincubator/create-react-app/issues/253
-    modules: ['node_modules'].concat(paths.nodePaths),
-    // These are the reasonable defaults supported by the Node ecosystem.
-    // We also include JSX as a common component filename extension to support
-    // some tools, although we do not recommend using it, see:
-    // https://github.com/facebookincubator/create-react-app/issues/290
-    extensions: ['.js', '.json', '.jsx'],
-    alias: {
-      // Support React Native Web
-      // https://www.smashingmagazine.com/2016/08/a-glimpse-into-the-future-with-react-native-for-web/
-      'react-native': 'react-native-web',
-    },
-  },
-  // @remove-on-eject-begin
-  // Resolve loaders (webpack plugins for CSS, images, transpilation) from the
-  // directory of `bem-react-scripts` itself rather than the project directory.
-  resolveLoader: {
-    modules: [
-      paths.ownNodeModules,
-      // Lerna hoists everything, so we need to look in our app directory
-      paths.appNodeModules,
-    ],
-  },
-  // @remove-on-eject-end
-  module: {
-    rules: [
-      // Disable require.ensure as it's not a standard language feature.
-      { parser: { requireEnsure: false } },
-      // First, run the linter.
-      // It's important to do this before Babel processes the JS.
-      {
-        test: /\.(js|jsx)$/,
-        enforce: 'pre',
-        use: [
-          {
-            // @remove-on-eject-begin
-            // Point ESLint to our predefined config.
-            options: {
-              // TODO: consider separate config for production,
-              // e.g. to enable no-console and no-debugger only in production.
-              configFile: path.join(__dirname, '../eslintrc'),
-              useEslintrc: false,
-            },
-            // @remove-on-eject-end
-            loader: 'eslint-loader',
-          },
-        ],
-        include: paths.appSrc,
-      },
-      // ** ADDING/UPDATING LOADERS **
-      // The "url" loader handles all assets unless explicitly excluded.
-      // The `exclude` list *must* be updated with every change to loader extensions.
-      // When adding a new loader, you must add its `test`
-      // as a new entry in the `exclude` list in the "url" loader.
+function getConfig(setName) {
+    const name = setName || '[name]';
+    const appBuild = setName ? `${paths.appBuild}/${setName}` : paths.appBuild;
 
-      // "file" loader makes sure those assets end up in the `build` folder.
-      // When you `import` an asset, you get its filename.
-      {
-        exclude: [
-          /\.html$/,
-          /\.(js|jsx)$/,
-          /\.css$/,
-          /\.json$/,
-          /\.bmp$/,
-          /\.gif$/,
-          /\.jpe?g$/,
-          /\.png$/,
-          /\.inline\.\w+$/,
-        ],
-        loader: 'file-loader',
-        options: {
-          name: 'static/media/[name].[hash:8].[ext]',
+    // Note: defined here because it will be used more than once.
+    var cssFilename = `static/css/${name}.[contenthash:8].css`;
+
+    // ExtractTextPlugin expects the build output to be flat.
+    // (See https://github.com/webpack-contrib/extract-text-webpack-plugin/issues/27)
+    // However, our output is structured with css, js and media folders.
+    // To have this structure working with relative paths, we have to use custom options.
+    const extractTextPluginOptions = shouldUseRelativeAssetPaths
+        ? // Making sure that the publicPath goes back to to build folder.
+        { publicPath: Array(cssFilename.split('/').length).join('../') }
+        : {};
+
+    return {
+        // Don't attempt to continue if there are any errors.
+        bail: true,
+        // We generate sourcemaps in production. This is slow but gives good results.
+        // You can exclude the *.map files from the build during deployment.
+        devtool: 'source-map',
+        // In production, we only want to load the polyfills and the app code.
+        entry: paths.appIndexJs,
+        output: {
+            // The build folder.
+            path: appBuild,
+            // Generated JS file names (with nested folders).
+            // There will be one main bundle, and one file per asynchronous chunk.
+            // We don't currently advertise code splitting but Webpack supports it.
+            filename: `static/js/${name}.[chunkhash:8].js`,
+            chunkFilename: `static/js/${name}.[chunkhash:8].chunk.js`,
+            // We inferred the "public path" (such as / or /my-project) from homepage.
+            publicPath: publicPath,
         },
-      },
-      // "url" loader works just like "file" loader but it also embeds
-      // assets smaller than specified size as data URLs to avoid requests.
-      {
-        test: [/\.bmp$/, /\.gif$/, /\.jpe?g$/, /\.png$/],
-        loader: 'url-loader',
-        options: {
-          limit: 10000,
-          name: 'static/media/[name].[hash:8].[ext]',
+        resolve: {
+            // This allows you to set a fallback for where Webpack should look for modules.
+            // We read `NODE_PATH` environment variable in `paths.js` and pass paths here.
+            // We placed these paths second because we want `node_modules` to "win"
+            // if there are any conflicts. This matches Node resolution mechanism.
+            // https://github.com/facebookincubator/create-react-app/issues/253
+            modules: ['node_modules'].concat(paths.nodePaths),
+            // These are the reasonable defaults supported by the Node ecosystem.
+            // We also include JSX as a common component filename extension to support
+            // some tools, although we do not recommend using it, see:
+            // https://github.com/facebookincubator/create-react-app/issues/290
+            extensions: ['.js', '.json', '.jsx'],
+            alias: {
+                // Support React Native Web
+                // https://www.smashingmagazine.com/2016/08/a-glimpse-into-the-future-with-react-native-for-web/
+                'react-native': 'react-native-web',
+            },
         },
-      },
-      // Process JS with Babel.
-      {
-        test: /\.(js|jsx)$/,
-        use: [
-          {
-            loader: 'webpack-bem-loader',
-            options: {
-              levels: paths.appLevels,
-              techs: ['js', 'css'],
-            },
-          },
-          {
-            loader: 'babel-loader',
-            options: {
-              // @remove-on-eject-begin
-              babelrc: false,
-              presets: [
-                require.resolve('babel-preset-es2015'),
-                require.resolve('babel-preset-react-app'),
-              ],
-              // @remove-on-eject-end
-              // This is a feature of `babel-loader` for webpack (not Babel itself).
-              // It enables caching results in ./node_modules/.cache/babel-loader/
-              // directory for faster rebuilds.
-              cacheDirectory: true,
-            },
-          },
-        ],
-        include: [paths.appSrc].concat(Object.keys(paths.appLevels)),
-      },
-      // The notation here is somewhat confusing.
-      // "postcss" loader applies autoprefixer to our CSS.
-      // "css" loader resolves paths in CSS and adds assets as dependencies.
-      // "style" loader normally turns CSS into JS modules injecting <style>,
-      // but unlike in development configuration, we do something different.
-      // `ExtractTextPlugin` first applies the "postcss" and "css" loaders
-      // (second argument), then grabs the result CSS and puts it into a
-      // separate file in our build process. This way we actually ship
-      // a single CSS file in production instead of JS code injecting <style>
-      // tags. If you use code splitting, however, any async bundles will still
-      // use the "style" loader inside the async code so CSS from them won't be
-      // in the main CSS file.
-      {
-        test: /\.css$/,
-        loader: ExtractTextPlugin.extract(
-          Object.assign(
-            {
-              fallback: 'style-loader',
-              use: [
+        // @remove-on-eject-begin
+        // Resolve loaders (webpack plugins for CSS, images, transpilation) from the
+        // directory of `bem-react-scripts` itself rather than the project directory.
+        resolveLoader: {
+            modules: [
+                paths.ownNodeModules,
+                // Lerna hoists everything, so we need to look in our app directory
+                paths.appNodeModules,
+            ],
+        },
+        // @remove-on-eject-end
+        module: {
+            rules: [
+                // Disable require.ensure as it's not a standard language feature.
+                { parser: { requireEnsure: false } },
+                // First, run the linter.
+                // It's important to do this before Babel processes the JS.
                 {
-                  loader: 'css-loader',
-                  options: {
-                    importLoaders: 1,
-                  },
+                    test: /\.(js|jsx)$/,
+                    enforce: 'pre',
+                    use: [
+                        {
+                            // @remove-on-eject-begin
+                            // Point ESLint to our predefined config.
+                            options: {
+                                // TODO: consider separate config for production,
+                                // e.g. to enable no-console and no-debugger only in production.
+                                configFile: path.join(__dirname, '../eslintrc'),
+                                useEslintrc: false,
+                            },
+                            // @remove-on-eject-end
+                            loader: 'eslint-loader',
+                        },
+                    ],
+                    include: paths.appSrc,
                 },
-                { loader: 'postcss-loader' },
-              ],
-            },
-            extractTextPluginOptions
-          )
-        ),
-        // Note: this won't work without `new ExtractTextPlugin()` in `plugins`.
-      },
-      {
-        test: /\.inline\.\w+$/,
-        loader: 'raw-loader',
-      },
-      // ** STOP ** Are you adding a new loader?
-      // Remember to add the new extension(s) to the "file" loader exclusion list.
-    ],
-  },
-  plugins: [
-    // Makes some environment variables available in index.html.
-    // The public URL is available as %PUBLIC_URL% in index.html, e.g.:
-    // <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico">
-    // In production, it will be an empty string unless you specify "homepage"
-    // in `package.json`, in which case it will be the pathname of that URL.
-    new InterpolateHtmlPlugin(env.raw),
-    // Generates an `index.html` file with the <script> injected.
-    new HtmlWebpackPlugin({
-      inject: true,
-      template: paths.appHtml,
-      minify: {
-        removeComments: true,
-        collapseWhitespace: true,
-        removeRedundantAttributes: true,
-        useShortDoctype: true,
-        removeEmptyAttributes: true,
-        removeStyleLinkTypeAttributes: true,
-        keepClosingSlash: true,
-        minifyJS: true,
-        minifyCSS: true,
-        minifyURLs: true,
-      },
-    }),
-    // Makes some environment variables available to the JS code, for example:
-    // if (process.env.NODE_ENV === 'production') { ... }. See `./env.js`.
-    // It is absolutely essential that NODE_ENV was set to production here.
-    // Otherwise React will be compiled in the very slow development mode.
-    new webpack.DefinePlugin(env.stringified),
-    // Minify the code.
-    new webpack.optimize.UglifyJsPlugin({
-      compress: {
-        screw_ie8: true, // React doesn't support IE8
-        warnings: false,
-      },
-      mangle: {
-        screw_ie8: true,
-      },
-      output: {
-        comments: false,
-        screw_ie8: true,
-      },
-      sourceMap: true,
-    }),
-    // Note: this won't work without ExtractTextPlugin.extract(..) in `loaders`.
-    new ExtractTextPlugin({
-      filename: cssFilename,
-    }),
-    // Generate a manifest file which contains a mapping of all asset filenames
-    // to their corresponding output file so that tools can pick it up without
-    // having to parse `index.html`.
-    new ManifestPlugin({
-      fileName: 'asset-manifest.json',
-    }),
-  ],
-  // Some libraries import Node modules but don't use them in the browser.
-  // Tell Webpack to provide empty mocks for them so importing them works.
-  node: {
-    fs: 'empty',
-    net: 'empty',
-    tls: 'empty',
-  },
-  target: paths.appTarget,
-};
+                // ** ADDING/UPDATING LOADERS **
+                // The "url" loader handles all assets unless explicitly excluded.
+                // The `exclude` list *must* be updated with every change to loader extensions.
+                // When adding a new loader, you must add its `test`
+                // as a new entry in the `exclude` list in the "url" loader.
+
+                // "file" loader makes sure those assets end up in the `build` folder.
+                // When you `import` an asset, you get its filename.
+                {
+                    exclude: [
+                        /\.html$/,
+                        /\.(js|jsx)$/,
+                        /\.css$/,
+                        /\.json$/,
+                        /\.bmp$/,
+                        /\.gif$/,
+                        /\.jpe?g$/,
+                        /\.png$/,
+                        /\.inline\.\w+$/,
+                    ],
+                    loader: 'file-loader',
+                    options: {
+                        name: 'static/media/[name].[hash:8].[ext]',
+                    },
+                },
+                // "url" loader works just like "file" loader but it also embeds
+                // assets smaller than specified size as data URLs to avoid requests.
+                {
+                    test: [/\.bmp$/, /\.gif$/, /\.jpe?g$/, /\.png$/],
+                    loader: 'url-loader',
+                    options: {
+                        limit: 10000,
+                        name: `static/media/[name].[hash:8].[ext]`,
+                    },
+                },
+                // Process JS with Babel.
+                {
+                    test: /\.(js|jsx)$/,
+                    use: [
+                        {
+                            loader: 'webpack-bem-loader',
+                            options: {
+                                levels: paths.appLevels,
+                                set: setName,
+                                techs: ['js', 'css']
+                            },
+                        },
+                        {
+                            loader: 'babel-loader',
+                            options: {
+                                // @remove-on-eject-begin
+                                babelrc: false,
+                                presets: [
+                                    require.resolve('babel-preset-es2015'),
+                                    require.resolve('babel-preset-react-app'),
+                                ],
+                                // @remove-on-eject-end
+                                // This is a feature of `babel-loader` for webpack (not Babel itself).
+                                // It enables caching results in ./node_modules/.cache/babel-loader/
+                                // directory for faster rebuilds.
+                                cacheDirectory: true,
+                            },
+                        },
+                    ],
+                    include: [paths.appSrc].concat(Object.keys(paths.appLevels)),
+                },
+                // The notation here is somewhat confusing.
+                // "postcss" loader applies autoprefixer to our CSS.
+                // "css" loader resolves paths in CSS and adds assets as dependencies.
+                // "style" loader normally turns CSS into JS modules injecting <style>,
+                // but unlike in development configuration, we do something different.
+                // `ExtractTextPlugin` first applies the "postcss" and "css" loaders
+                // (second argument), then grabs the result CSS and puts it into a
+                // separate file in our build process. This way we actually ship
+                // a single CSS file in production instead of JS code injecting <style>
+                // tags. If you use code splitting, however, any async bundles will still
+                // use the "style" loader inside the async code so CSS from them won't be
+                // in the main CSS file.
+                {
+                    test: /\.css$/,
+                    loader: ExtractTextPlugin.extract(
+                        Object.assign(
+                            {
+                                fallback: 'style-loader',
+                                use: [
+                                    {
+                                        loader: 'css-loader',
+                                        options: {
+                                            importLoaders: 1,
+                                        },
+                                    },
+                                    { loader: 'postcss-loader' },
+                                ],
+                            },
+                            extractTextPluginOptions
+                        )
+                    ),
+                    // Note: this won't work without `new ExtractTextPlugin()` in `plugins`.
+                },
+                {
+                    test: /\.inline\.\w+$/,
+                    loader: 'raw-loader',
+                },
+                // ** STOP ** Are you adding a new loader?
+                // Remember to add the new extension(s) to the "file" loader exclusion list.
+            ],
+        },
+        plugins: [
+            // Makes some environment variables available in index.html.
+            // The public URL is available as %PUBLIC_URL% in index.html, e.g.:
+            // <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico">
+            // In production, it will be an empty string unless you specify "homepage"
+            // in `package.json`, in which case it will be the pathname of that URL.
+            new InterpolateHtmlPlugin(env.raw),
+            // Generates an `index.html` file with the <script> injected.
+            new HtmlWebpackPlugin({
+              inject: true,
+              template: paths.appHtml,
+              filename: `${appBuild}/index.html`,
+              minify: {
+                removeComments: true,
+                collapseWhitespace: true,
+                removeRedundantAttributes: true,
+                useShortDoctype: true,
+                removeEmptyAttributes: true,
+                removeStyleLinkTypeAttributes: true,
+                keepClosingSlash: true,
+                minifyJS: true,
+                minifyCSS: true,
+                minifyURLs: true,
+              }
+            }),
+            // Makes some environment variables available to the JS code, for example:
+            // if (process.env.NODE_ENV === 'production') { ... }. See `./env.js`.
+            // It is absolutely essential that NODE_ENV was set to production here.
+            // Otherwise React will be compiled in the very slow development mode.
+            new webpack.DefinePlugin(env.stringified),
+            // Minify the code.
+            new webpack.optimize.UglifyJsPlugin({
+                compress: {
+                    screw_ie8: true, // React doesn't support IE8
+                    warnings: false,
+                },
+                mangle: {
+                    screw_ie8: true,
+                },
+                output: {
+                    comments: false,
+                    screw_ie8: true,
+                },
+                sourceMap: true,
+            }),
+            // Note: this won't work without ExtractTextPlugin.extract(..) in `loaders`.
+            new ExtractTextPlugin({
+                filename: cssFilename,
+            }),
+            // Generate a manifest file which contains a mapping of all asset filenames
+            // to their corresponding output file so that tools can pick it up without
+            // having to parse `index.html`.
+            new ManifestPlugin({
+                fileName: 'asset-manifest.json',
+            }),
+        ],
+        // Some libraries import Node modules but don't use them in the browser.
+        // Tell Webpack to provide empty mocks for them so importing them works.
+        node: {
+            fs: 'empty',
+            net: 'empty',
+            tls: 'empty',
+        },
+        target: paths.appTarget,
+    };
+}
+
+module.exports = paths.appSets ?
+    Object.keys(paths.appSets).map(setName => getConfig(setName)) :
+    getConfig();

--- a/packages/bem-react-scripts/config/webpackDevServer.config.js
+++ b/packages/bem-react-scripts/config/webpackDevServer.config.js
@@ -16,6 +16,9 @@ const paths = require('./paths');
 const protocol = process.env.HTTPS === 'true' ? 'https' : 'http';
 const host = process.env.HOST || 'localhost';
 
+// Get setName name, after start app like `npm run start setName`
+const setName = process.argv[2];
+
 module.exports = {
   // Enable gzip compression of generated files.
   compress: true,
@@ -36,7 +39,7 @@ module.exports = {
   // for files like `favicon.ico`, `manifest.json`, and libraries that are
   // for some reason broken when imported through Webpack. If you just want to
   // use an image, put it in `src` and `import` it from JavaScript instead.
-  contentBase: paths.appPublic,
+  contentBase: setName ? `${paths.appBuild}/${setName}` : paths.appBuild,
   // By default files from `contentBase` will not trigger a page reload.
   watchContentBase: true,
   // Enable hot reloading server. It will provide /sockjs-node/ endpoint

--- a/packages/bem-react-scripts/package.json
+++ b/packages/bem-react-scripts/package.json
@@ -55,6 +55,7 @@
     "http-proxy-middleware": "0.17.3",
     "jest": "18.1.0",
     "object-assign": "4.1.1",
+    "parallel-webpack": "^2.2.0",
     "postcss-loader": "1.3.3",
     "promise": "7.1.1",
     "raw-loader": "^0.5.1",
@@ -67,7 +68,8 @@
     "webpack-bem-loader": "^0.4.1",
     "webpack-dev-server": "2.4.1",
     "webpack-manifest-plugin": "1.1.0",
-    "whatwg-fetch": "2.0.2"
+    "whatwg-fetch": "2.0.2",
+    "minimist": "1.2.0"
   },
   "devDependencies": {
     "react": "^15.3.0",

--- a/packages/bem-react-scripts/scripts/build.js
+++ b/packages/bem-react-scripts/scripts/build.js
@@ -23,8 +23,18 @@ const chalk = require('chalk');
 const fs = require('fs-extra');
 const path = require('path');
 const url = require('url');
-const webpack = require('webpack');
-const config = require('../config/webpack.config.prod');
+
+const parallelWebpack = require('parallel-webpack');
+const parallelWebpackArgv = require('minimist')(process.argv.slice(2), {
+    '--': true,
+    default: {
+        watch: false,
+        maxRetries: 1,
+        stats: true
+    }
+});
+
+const configPath = require.resolve('../config/webpack.config.prod');
 const paths = require('../config/paths');
 const checkRequiredFiles = require('react-dev-utils/checkRequiredFiles');
 const FileSizeReporter = require('react-dev-utils/FileSizeReporter');
@@ -66,134 +76,19 @@ function printErrors(summary, errors) {
 function build(previousFileSizes) {
   console.log('Creating an optimized production build...');
 
-  let compiler;
   try {
-    compiler = webpack(config);
+    parallelWebpack.run(
+        configPath,
+        {
+            watch: parallelWebpackArgv.watch,
+            maxRetries: parallelWebpackArgv.maxRetries,
+            stats: parallelWebpackArgv.stats
+        }
+    );
   } catch (err) {
     printErrors('Failed to compile.', [err]);
     process.exit(1);
   }
-
-  compiler.run((err, stats) => {
-    if (err) {
-      printErrors('Failed to compile.', [err]);
-      process.exit(1);
-    }
-
-    if (stats.compilation.errors.length) {
-      printErrors('Failed to compile.', stats.compilation.errors);
-      process.exit(1);
-    }
-
-    if (process.env.CI && stats.compilation.warnings.length) {
-      printErrors(
-        'Failed to compile. When process.env.CI = true, warnings are treated as failures. Most CI servers set this automatically.',
-        stats.compilation.warnings
-      );
-      process.exit(1);
-    }
-
-    console.log(chalk.green('Compiled successfully.'));
-    console.log();
-
-    console.log('File sizes after gzip:');
-    console.log();
-    printFileSizesAfterBuild(stats, previousFileSizes);
-    console.log();
-
-    const appPackage = require(paths.appPackageJson);
-    const publicUrl = paths.publicUrl;
-    const publicPath = config.output.publicPath;
-    const publicPathname = url.parse(publicPath).pathname;
-    if (publicUrl && publicUrl.indexOf('.github.io/') !== -1) {
-      // "homepage": "http://user.github.io/project"
-      console.log(
-        `The project was built assuming it is hosted at ${chalk.green(publicPathname)}.`
-      );
-      console.log(
-        `You can control this with the ${chalk.green('homepage')} field in your ${chalk.cyan('package.json')}.`
-      );
-      console.log();
-      console.log(`The ${chalk.cyan('build')} folder is ready to be deployed.`);
-      console.log(`To publish it at ${chalk.green(publicUrl)}, run:`);
-      // If script deploy has been added to package.json, skip the instructions
-      if (typeof appPackage.scripts.deploy === 'undefined') {
-        console.log();
-        if (useYarn) {
-          console.log(`  ${chalk.cyan('yarn')} add --dev gh-pages`);
-        } else {
-          console.log(`  ${chalk.cyan('npm')} install --save-dev gh-pages`);
-        }
-        console.log();
-        console.log(
-          `Add the following script in your ${chalk.cyan('package.json')}.`
-        );
-        console.log();
-        console.log(`    ${chalk.dim('// ...')}`);
-        console.log(`    ${chalk.yellow('"scripts"')}: {`);
-        console.log(`      ${chalk.dim('// ...')}`);
-        console.log(
-          `      ${chalk.yellow('"predeploy"')}: ${chalk.yellow('"npm run build",')}`
-        );
-        console.log(
-          `      ${chalk.yellow('"deploy"')}: ${chalk.yellow('"gh-pages -d build"')}`
-        );
-        console.log('    }');
-        console.log();
-        console.log('Then run:');
-      }
-      console.log();
-      console.log(`  ${chalk.cyan(useYarn ? 'yarn' : 'npm')} run deploy`);
-      console.log();
-    } else if (publicPath !== '/') {
-      // "homepage": "http://mywebsite.com/project"
-      console.log(
-        `The project was built assuming it is hosted at ${chalk.green(publicPath)}.`
-      );
-      console.log(
-        `You can control this with the ${chalk.green('homepage')} field in your ${chalk.cyan('package.json')}.`
-      );
-      console.log();
-      console.log(`The ${chalk.cyan('build')} folder is ready to be deployed.`);
-      console.log();
-    } else {
-      if (publicUrl) {
-        // "homepage": "http://mywebsite.com"
-        console.log(
-          `The project was built assuming it is hosted at ${chalk.green(publicUrl)}.`
-        );
-        console.log(
-          `You can control this with the ${chalk.green('homepage')} field in your ${chalk.cyan('package.json')}.`
-        );
-        console.log();
-      } else {
-        // no homepage
-        console.log(
-          'The project was built assuming it is hosted at the server root.'
-        );
-        console.log(
-          `To override this, specify the ${chalk.green('homepage')} in your ${chalk.cyan('package.json')}.`
-        );
-        console.log('For example, add this to build it for GitHub Pages:');
-        console.log();
-        console.log(
-          `  ${chalk.green('"homepage"')} ${chalk.cyan(':')} ${chalk.green('"http://myname.github.io/myapp"')}${chalk.cyan(',')}`
-        );
-        console.log();
-      }
-      const build = path.relative(process.cwd(), paths.appBuild);
-      console.log(`The ${chalk.cyan(build)} folder is ready to be deployed.`);
-      console.log('You may serve it with a static server:');
-      console.log();
-      if (useYarn) {
-        console.log(`  ${chalk.cyan('yarn')} global add serve`);
-      } else {
-        console.log(`  ${chalk.cyan('npm')} install -g serve`);
-      }
-      console.log(`  ${chalk.cyan('serve')} -s build`);
-      console.log();
-    }
-  });
 }
 
 function copyPublicFolder() {


### PR DESCRIPTION
Add [sets](https://github.com/bem/bem-sdk/pull/213) support 

For each set run multiple webpack builds in parallel (using parallel-webpack)
Each set builds in ```appBuild/setName/```
If no set static files will be in ```appBuild/main/```

Run webpackDevServer with command  ```npm run start setName``` 
if no set ```npm run start```  

<!--
Thank you for sending the PR!
If you changed any code, there are just two more things to do:

* Provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
