### PR TITLE
Fix sets using in dev mode

### DIFF
--- a/packages/bem-react-scripts/config/webpack.config.dev.js
+++ b/packages/bem-react-scripts/config/webpack.config.dev.js
@@ -139,7 +139,7 @@ module.exports = {
           {
             loader: 'webpack-bem-loader',
             options: {
-              levels: paths.appLevels,
+              levels: setName ? paths.appSets[setName] : paths.appLevels,
               techs: ['js', 'css'],
             },
           },


### PR DESCRIPTION
When you use sets (e.g. desktop and touch) and layers (e.g. common, desktop, touch), webpack correct create js/css for production, but in dev mode all layers are built into one pile

/cc @awinogradov @zxqfox 